### PR TITLE
Added dockerfile-context input for the docker_build_aws_ecr action

### DIFF
--- a/.github/workflows/docker_build_aws_ecr.yaml
+++ b/.github/workflows/docker_build_aws_ecr.yaml
@@ -44,6 +44,11 @@ on:
         description: The branch from dockerfile-repo to checkout (defaults to the default branch if not specified)
         type: string
         required: false
+      dockerfile-context:
+        description: The context of the Dockerfile
+        type: string
+        required: false
+        default: .
       debug:
         type: string
         required: false
@@ -153,6 +158,7 @@ jobs:
         if: ${{ ! inputs.max-cache }}
         uses: docker/build-push-action@v2
         with:
+          context: ${{ inputs.dockerfile-context }}
           push: true
           cache-from: |
             type=registry,ref=${{env.DOCKER_IMAGE}}:latest


### PR DESCRIPTION
There where no option to specify the Dockerfile context.